### PR TITLE
Possible Fix for Issue #1

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -43,7 +43,8 @@
     </project-components>
 
     <depends>com.intellij.modules.ultimate</depends>
-    <depends>com.intellij.persistence.database</depends>
+    <depends optional="true">com.intellij.database</depends>
+    <depends optional="true">com.intellij.persistence.database</depends>
 
     <actions>
         <action id="sqlGenerate" class="org.yseasony.sqlgenerator.SqlGeneratorAction">

--- a/src/org/yseasony/sqlgenerator/SqlGenerator.java
+++ b/src/org/yseasony/sqlgenerator/SqlGenerator.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 
-import com.intellij.persistence.database.psi.DbColumnElement;
+import com.intellij.database.psi.DbColumnElement;
 
 public class SqlGenerator {
 

--- a/src/org/yseasony/sqlgenerator/SqlGeneratorAction.java
+++ b/src/org/yseasony/sqlgenerator/SqlGeneratorAction.java
@@ -9,9 +9,9 @@ import org.yseasony.sqlgenerator.children.SelectSqlGeneratorAction;
 import com.intellij.openapi.actionSystem.ActionGroup;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.persistence.database.TableType;
-import com.intellij.persistence.database.psi.DbTableElement;
-import com.intellij.persistence.database.view.DatabaseView;
+import com.intellij.database.model.TableType;
+import com.intellij.database.psi.DbTableElement;
+import com.intellij.database.view.DatabaseView;
 import org.yseasony.sqlgenerator.children.UpdateSqlGeneratorAction;
 
 /**

--- a/src/org/yseasony/sqlgenerator/TableInfo.java
+++ b/src/org/yseasony/sqlgenerator/TableInfo.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.collect.Lists;
-import com.intellij.persistence.database.psi.DbColumnElement;
-import com.intellij.persistence.database.psi.DbTableElement;
+import com.intellij.database.psi.DbColumnElement;
+import com.intellij.database.psi.DbTableElement;
 
 public class TableInfo {
 

--- a/src/org/yseasony/sqlgenerator/Util.java
+++ b/src/org/yseasony/sqlgenerator/Util.java
@@ -3,7 +3,7 @@ package org.yseasony.sqlgenerator;
 import java.util.List;
 import java.util.Locale;
 
-import com.intellij.persistence.database.psi.DbColumnElement;
+import com.intellij.database.psi.DbColumnElement;
 
 public final class Util {
 

--- a/src/org/yseasony/sqlgenerator/children/BaseSqlGenerator.java
+++ b/src/org/yseasony/sqlgenerator/children/BaseSqlGenerator.java
@@ -9,9 +9,9 @@ import org.yseasony.sqlgenerator.Util;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.ide.CopyPasteManager;
-import com.intellij.persistence.database.TableType;
-import com.intellij.persistence.database.psi.DbTableElement;
-import com.intellij.persistence.database.view.DatabaseView;
+import com.intellij.database.model.TableType;
+import com.intellij.database.psi.DbTableElement;
+import com.intellij.database.view.DatabaseView;
 
 /**
  * 类BaseSqlGenerator.java

--- a/src/org/yseasony/sqlgenerator/children/InsertSqlGeneratorAction.java
+++ b/src/org/yseasony/sqlgenerator/children/InsertSqlGeneratorAction.java
@@ -7,7 +7,7 @@ import org.yseasony.sqlgenerator.SqlGenerator;
 import org.yseasony.sqlgenerator.TableInfo;
 import org.yseasony.sqlgenerator.Util;
 
-import com.intellij.persistence.database.psi.DbColumnElement;
+import com.intellij.database.psi.DbColumnElement;
 
 public class InsertSqlGeneratorAction extends BaseSqlGenerator {
 

--- a/src/org/yseasony/sqlgenerator/children/UpdateSqlGeneratorAction.java
+++ b/src/org/yseasony/sqlgenerator/children/UpdateSqlGeneratorAction.java
@@ -7,7 +7,7 @@ import org.yseasony.sqlgenerator.SqlGenerator;
 import org.yseasony.sqlgenerator.TableInfo;
 import org.yseasony.sqlgenerator.Util;
 
-import com.intellij.persistence.database.psi.DbColumnElement;
+import com.intellij.database.psi.DbColumnElement;
 
 public class UpdateSqlGeneratorAction extends BaseSqlGenerator {
 


### PR DESCRIPTION
**NOTE:** Breaks compatibility with IDEA. I don't write enough Java to know if there's any preprocessing capabilities, or a method for conditionally referencing namespaces. Not sure if you want to deal with managing multiple branches, but I figured I might as well offer the changes.

Turns out that the namespaces and plugin id for the Database Tools plugin in PyCharm differs from the Persistence plugin used in IDEA. Since most of the IDEA offshoot IDEs resemble one another more than IDEA itself, I imagine this should probably fix compatibility with the other IDEs. (PHPStorm, WebStorm, etc)

, 
